### PR TITLE
Refactor NodeProto ONNX pb helpers

### DIFF
--- a/cli/src/errors.rs
+++ b/cli/src/errors.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use ndarray;
 use tract_core;
 

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -1,4 +1,5 @@
 //! error_chain generated types
+#![allow(deprecated)]
 
 error_chain! {
     types {

--- a/core/src/ops/array/pad.rs
+++ b/core/src/ops/array/pad.rs
@@ -1,6 +1,7 @@
 use crate::ops::prelude::*;
 use ndarray::*;
 use num_traits::AsPrimitive;
+use std::str::FromStr;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum PadMode {
@@ -8,6 +9,19 @@ pub enum PadMode {
     Reflect,
     Edge,
 }
+
+impl FromStr for PadMode {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "reflect" => Ok(PadMode::Reflect),
+            "edge" => Ok(PadMode::Edge),
+            _ => Err(())
+        }
+    }
+}
+
 impl Default for PadMode {
     fn default() -> PadMode {
         PadMode::Constant(0.0)

--- a/core/src/ops/array/pad.rs
+++ b/core/src/ops/array/pad.rs
@@ -1,25 +1,12 @@
 use crate::ops::prelude::*;
 use ndarray::*;
 use num_traits::AsPrimitive;
-use std::str::FromStr;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum PadMode {
     Constant(f32),
     Reflect,
     Edge,
-}
-
-impl FromStr for PadMode {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "reflect" => Ok(PadMode::Reflect),
-            "edge" => Ok(PadMode::Edge),
-            _ => Err(())
-        }
-    }
 }
 
 impl Default for PadMode {

--- a/core/src/ops/nn/padding.rs
+++ b/core/src/ops/nn/padding.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::ops::prelude::*;
 
 #[derive(Debug, Clone)]
@@ -6,6 +8,20 @@ pub enum PaddingSpec {
     Valid,
     SameUpper,
     SameLower,
+}
+
+impl FromStr for PaddingSpec {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NOTSET" => Ok(PaddingSpec::Valid),
+            "VALID" => Ok(PaddingSpec::Valid),
+            "SAME_UPPER" => Ok(PaddingSpec::SameUpper),
+            "SAME_LOWER" => Ok(PaddingSpec::SameLower),
+            _ => Err(()),
+        }
+    }
 }
 
 impl Default for PaddingSpec {

--- a/core/src/ops/nn/padding.rs
+++ b/core/src/ops/nn/padding.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use crate::ops::prelude::*;
 
 #[derive(Debug, Clone)]
@@ -8,20 +6,6 @@ pub enum PaddingSpec {
     Valid,
     SameUpper,
     SameLower,
-}
-
-impl FromStr for PaddingSpec {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "NOTSET" => Ok(PaddingSpec::Valid),
-            "VALID" => Ok(PaddingSpec::Valid),
-            "SAME_UPPER" => Ok(PaddingSpec::SameUpper),
-            "SAME_LOWER" => Ok(PaddingSpec::SameLower),
-            _ => Err(()),
-        }
-    }
 }
 
 impl Default for PaddingSpec {

--- a/onnx/Cargo.toml
+++ b/onnx/Cargo.toml
@@ -21,6 +21,7 @@ ndarray = { version = "0.12" }
 num-integer = "0.1"
 num-traits = "0.2"
 protobuf = "2.0"
+smallvec = "0.6"
 tract-linalg = { path = "../linalg" }
 tract-core = { path = "../core" }
 

--- a/onnx/src/ops/array/mod.rs
+++ b/onnx/src/ops/array/mod.rs
@@ -106,7 +106,11 @@ pub fn pad(node: &NodeProto) -> TractResult<Box<Op>> {
     let value = node.get_attr_opt("value")?;
     let mode = match node.get_attr_opt("mode")? {
         None | Some("constant") => None,
-        Some(mode) => Some(node.parse_str("mode", mode)?),
+        Some(mode) => node.check_value("mode", match mode {
+            "reflect" => Ok(Some(tractops::array::PadMode::Reflect)),
+            "edge" => Ok(Some(tractops::array::PadMode::Edge)),
+            _ => Err(mode)
+        })?
     }.unwrap_or_else(||
         tractops::array::PadMode::Constant(value.unwrap_or(0.))
     );

--- a/onnx/src/ops/array/mod.rs
+++ b/onnx/src/ops/array/mod.rs
@@ -73,7 +73,7 @@ pub fn constant_like(node: &NodeProto) -> TractResult<Box<Op>> {
 }
 
 pub fn constant_of_shape(node: &NodeProto) -> TractResult<Box<Op>> {
-    let value = match node.get_attr_opt_tensor("value")? {
+    let value = match node.get_attr_opt::<Tensor>("value")? {
         Some(val) => val.into_tensor(),
         None => make_const::<f32>(&vec![1], 0.0 as f32)?,
     };

--- a/onnx/src/ops/array/mod.rs
+++ b/onnx/src/ops/array/mod.rs
@@ -36,8 +36,8 @@ pub fn register_all_ops(reg: &mut OpRegister) {
 }
 
 pub fn concat(node: &NodeProto) -> TractResult<Box<Op>> {
-    let axis = node.get_attr_int("axis")?;
-    Ok(Box::new(tractops::array::Concat::new(axis as usize)))
+    let axis = node.get_attr("axis")?;
+    Ok(Box::new(tractops::array::Concat::new(axis)))
 }
 
 pub fn make_const<T>(shape: &[usize], v: f32) -> TractResult<SharedTensor>
@@ -52,8 +52,8 @@ pub fn constant_like(node: &NodeProto) -> TractResult<Box<Op>> {
     let value = node.get_attr_opt_float("value")?.unwrap_or(0.0);
     if node.get_input().len() == 0 {
         use protobuf::ProtobufEnum;
-        let dt = match node.get_attr_opt_int("dtype")? {
-            Some(dt) => pb::TensorProto_DataType::from_i32(dt as i32)
+        let dt = match node.get_attr_opt("dtype")? {
+            Some(dt) => pb::TensorProto_DataType::from_i32(dt)
                 .ok_or_else(|| {
                     format!("Can not convert integer {} into a TensorProto_DataType", dt)
                 })?
@@ -82,9 +82,9 @@ pub fn constant_of_shape(node: &NodeProto) -> TractResult<Box<Op>> {
 
 pub fn eye_like(node: &NodeProto) -> TractResult<Box<Op>> {
     use protobuf::ProtobufEnum;
-    let dt = match node.get_attr_opt_int("dtype")? {
+    let dt = match node.get_attr_opt("dtype")? {
         Some(dt) => Some(
-            pb::TensorProto_DataType::from_i32(dt as i32)
+            pb::TensorProto_DataType::from_i32(dt)
                 .ok_or_else(|| {
                     format!("Can not convert integer {} into a TensorProto_DataType", dt)
                 })?
@@ -92,17 +92,17 @@ pub fn eye_like(node: &NodeProto) -> TractResult<Box<Op>> {
         ),
         None => None,
     };
-    let k = node.get_attr_opt_int("k")?.unwrap_or(0);
-    Ok(Box::new(tractops::array::EyeLike::new(dt, k as isize)))
+    let k = node.get_attr_opt("k")?.unwrap_or(0);
+    Ok(Box::new(tractops::array::EyeLike::new(dt, k)))
 }
 
 pub fn flatten(node: &NodeProto) -> TractResult<Box<Op>> {
-    let axis = node.get_attr_opt_int("axis")?.unwrap_or(1);
-    Ok(Box::new(tractops::array::Flatten::new(axis as usize)))
+    let axis = node.get_attr_opt("axis")?.unwrap_or(1);
+    Ok(Box::new(tractops::array::Flatten::new(axis)))
 }
 
 pub fn gather(node: &NodeProto) -> TractResult<Box<Op>> {
-    let axis = node.get_attr_opt_int("axis")?.unwrap_or(0);
+    let axis = node.get_attr_opt("axis")?.unwrap_or(0);
     Ok(Box::new(tractops::array::Gather::new(axis)))
 }
 
@@ -134,7 +134,7 @@ pub fn slice(node: &NodeProto) -> TractResult<Box<Op>> {
 }
 
 pub fn split(node: &NodeProto) -> TractResult<Box<Op>> {
-    let axis = node.get_attr_opt_int("axis")?.unwrap_or(0);
+    let axis = node.get_attr_opt("axis")?.unwrap_or(0);
     let split = node.get_attr_opt_ints("split")?;
     Ok(Box::new(tractops::array::Split::new(
         axis as usize,

--- a/onnx/src/ops/array/mod.rs
+++ b/onnx/src/ops/array/mod.rs
@@ -107,13 +107,13 @@ pub fn gather(node: &NodeProto) -> TractResult<Box<Op>> {
 }
 
 pub fn pad(node: &NodeProto) -> TractResult<Box<Op>> {
-    let mode = node.get_attr_opt_str("mode")?;
     let value = node.get_attr_opt("value")?;
-    let mode = match mode {
-        Some("reflect") => tractops::array::PadMode::Reflect,
-        Some("edge") => tractops::array::PadMode::Edge,
-        _ => tractops::array::PadMode::Constant(value.unwrap_or(0.)),
-    };
+    let mode = match node.get_attr_opt("mode")? {
+        None | Some("constant") => None,
+        Some(mode) => Some(node.parse_str("mode", mode)?),
+    }.unwrap_or_else(||
+        tractops::array::PadMode::Constant(value.unwrap_or(0.))
+    );
     let pads = node.get_attr_ints("pads")?;
     let rank = pads.len() / 2;
     let pads = (0..rank)

--- a/onnx/src/ops/array/mod.rs
+++ b/onnx/src/ops/array/mod.rs
@@ -49,7 +49,7 @@ where
 }
 
 pub fn constant_like(node: &NodeProto) -> TractResult<Box<Op>> {
-    let value = node.get_attr_opt_float("value")?.unwrap_or(0.0);
+    let value = node.get_attr_opt("value")?.unwrap_or(0.);
     if node.get_input().len() == 0 {
         use protobuf::ProtobufEnum;
         let dt = match node.get_attr_opt("dtype")? {
@@ -108,11 +108,11 @@ pub fn gather(node: &NodeProto) -> TractResult<Box<Op>> {
 
 pub fn pad(node: &NodeProto) -> TractResult<Box<Op>> {
     let mode = node.get_attr_opt_str("mode")?;
-    let value = node.get_attr_opt_float("value")?;
+    let value = node.get_attr_opt("value")?;
     let mode = match mode {
         Some("reflect") => tractops::array::PadMode::Reflect,
         Some("edge") => tractops::array::PadMode::Edge,
-        _ => tractops::array::PadMode::Constant(value.unwrap_or(0.0)),
+        _ => tractops::array::PadMode::Constant(value.unwrap_or(0.)),
     };
     let pads = node.get_attr_ints("pads")?;
     let rank = pads.len() / 2;

--- a/onnx/src/ops/math.rs
+++ b/onnx/src/ops/math.rs
@@ -55,14 +55,14 @@ pub fn register_all_ops(reg: &mut OpRegister) {
 }
 
 pub fn clip(node: &NodeProto) -> TractResult<Box<Op>> {
-    let min = node.get_attr_opt_float("min")?.unwrap_or(::std::f32::MIN);
-    let max = node.get_attr_opt_float("max")?.unwrap_or(::std::f32::MAX);
+    let min = node.get_attr_opt("min")?.unwrap_or(::std::f32::MIN);
+    let max = node.get_attr_opt("max")?.unwrap_or(::std::f32::MAX);
     Ok(Box::new(tractops::math::Clip::new(min, max)))
 }
 
 pub fn gemm(node: &NodeProto) -> TractResult<Box<Op>> {
-    let alpha = node.get_attr_opt_float("alpha")?.unwrap_or(1.0);
-    let beta = node.get_attr_opt_float("beta")?.unwrap_or(1.0);
+    let alpha = node.get_attr_opt("alpha")?.unwrap_or(1.);
+    let beta = node.get_attr_opt("beta")?.unwrap_or(1.);
     let trans_a = node.get_attr_opt("transA")?.unwrap_or(false);
     let trans_b = node.get_attr_opt("transB")?.unwrap_or(false);
     Ok(Box::new(tractops::math::Gemm::new(

--- a/onnx/src/ops/math.rs
+++ b/onnx/src/ops/math.rs
@@ -63,14 +63,8 @@ pub fn clip(node: &NodeProto) -> TractResult<Box<Op>> {
 pub fn gemm(node: &NodeProto) -> TractResult<Box<Op>> {
     let alpha = node.get_attr_opt_float("alpha")?.unwrap_or(1.0);
     let beta = node.get_attr_opt_float("beta")?.unwrap_or(1.0);
-    let trans_a = node
-        .get_attr_opt_int("transA")?
-        .map(|a| a != 0)
-        .unwrap_or(false);
-    let trans_b = node
-        .get_attr_opt_int("transB")?
-        .map(|a| a != 0)
-        .unwrap_or(false);
+    let trans_a = node.get_attr_opt("transA")?.unwrap_or(false);
+    let trans_b = node.get_attr_opt("transB")?.unwrap_or(false);
     Ok(Box::new(tractops::math::Gemm::new(
         alpha, beta, trans_a, trans_b, true,
     )))

--- a/onnx/src/ops/mod.rs
+++ b/onnx/src/ops/mod.rs
@@ -38,7 +38,7 @@ impl OpBuilder {
 }
 
 fn konst(node: &NodeProto) -> TractResult<Box<Op>> {
-    let v = node.get_attr_tensor("value")?;
+    let v = node.get_attr("value")?;
     Ok(Box::new(::tract_core::ops::konst::Const::for_tensor(v)))
 }
 

--- a/onnx/src/ops/mod.rs
+++ b/onnx/src/ops/mod.rs
@@ -45,8 +45,8 @@ fn konst(node: &NodeProto) -> TractResult<Box<Op>> {
 fn cast(node: &NodeProto) -> TractResult<Box<Op>> {
     use protobuf::ProtobufEnum;
     use tract_core::ToTract;
-    let to = node.get_attr_int("to")?;
-    let to = pb::TensorProto_DataType::from_i32(to as i32)
-        .ok_or_else(|| format!("Can not convert integer {} into a TensorProto_DataType", to))?;
+    let to = node.get_attr("to")?;
+    let to = pb::TensorProto_DataType::from_i32(to)
+        .ok_or_else(|| format!("Cannot convert integer {} into a TensorProto_DataType", to))?;
     Ok(Box::new(::tract_core::ops::cast::Cast::new(to.tractify()?)))
 }

--- a/onnx/src/ops/nn/mod.rs
+++ b/onnx/src/ops/nn/mod.rs
@@ -110,7 +110,7 @@ pub fn arg_max_min(node: &NodeProto) -> TractResult<Box<Op>> {
 }
 
 pub fn batch_normalization(node: &NodeProto) -> TractResult<Box<Op>> {
-    let epsilon = node.get_attr_opt_float("epsilon")?.unwrap_or(1e-5);
+    let epsilon = node.get_attr_opt("epsilon")?.unwrap_or(1e-5);
     let spatial = node.get_attr_opt("spatial")?.unwrap_or(0);
     assert_eq!(spatial, 0);
     Ok(Box::new(tractops::nn::BatchNorm::new(
@@ -155,7 +155,7 @@ pub fn average_pool(node: &NodeProto) -> TractResult<Box<Op>> {
 }
 
 pub fn elu(node: &NodeProto) -> TractResult<Box<Op>> {
-    let alpha = node.get_attr_opt_float("alpha")?.unwrap_or(1.0);
+    let alpha = node.get_attr_opt("alpha")?.unwrap_or(1.);
     Ok(Box::new(tractops::nn::Elu::new(alpha)))
 }
 
@@ -165,8 +165,8 @@ pub fn global_lp_pool(node: &NodeProto) -> TractResult<Box<Op>> {
 }
 
 pub fn hard_sigmoid(node: &NodeProto) -> TractResult<Box<Op>> {
-    let alpha = node.get_attr_opt_float("alpha")?.unwrap_or(0.2);
-    let beta = node.get_attr_opt_float("beta")?.unwrap_or(0.5);
+    let alpha = node.get_attr_opt("alpha")?.unwrap_or(0.2);
+    let beta = node.get_attr_opt("beta")?.unwrap_or(0.5);
     Ok(Box::new(tractops::nn::Hardsigmoid::new(alpha, beta)))
 }
 
@@ -186,14 +186,14 @@ pub fn layer_soft_max(node: &NodeProto) -> TractResult<Box<Op>> {
 }
 
 pub fn leaky_relu(node: &NodeProto) -> TractResult<Box<Op>> {
-    let alpha = node.get_attr_opt_float("alpha")?.unwrap_or(0.01);
+    let alpha = node.get_attr_opt("alpha")?.unwrap_or(0.01);
     Ok(Box::new(tractops::nn::LeakyRelu::new(alpha)))
 }
 
 pub fn lrn(node: &NodeProto) -> TractResult<Box<Op>> {
-    let alpha = node.get_attr_opt_float("alpha")?.unwrap_or(0.0001);
-    let beta = node.get_attr_opt_float("beta")?.unwrap_or(0.75);
-    let bias = node.get_attr_opt_float("bias")?.unwrap_or(1.0);
+    let alpha = node.get_attr_opt("alpha")?.unwrap_or(0.0001);
+    let beta = node.get_attr_opt("beta")?.unwrap_or(0.75);
+    let bias = node.get_attr_opt("bias")?.unwrap_or(1.);
     let size = node.get_attr("size")?;
     Ok(Box::new(tractops::nn::Lrn::new(alpha, beta, bias, size)))
 }
@@ -220,8 +220,8 @@ pub fn max_pool(node: &NodeProto) -> TractResult<Box<Op>> {
 }
 
 pub fn parametric_softplus(node: &NodeProto) -> TractResult<Box<Op>> {
-    let alpha = node.get_attr_float("alpha")?;
-    let beta = node.get_attr_float("beta")?;
+    let alpha = node.get_attr("alpha")?;
+    let beta = node.get_attr("beta")?;
     Ok(Box::new(tractops::nn::ParametricSoftplus::new(alpha, beta)))
 }
 
@@ -235,8 +235,8 @@ element_bin!(Prelu, match
 );
 
 pub fn scaled_tanh(node: &NodeProto) -> TractResult<Box<Op>> {
-    let alpha = node.get_attr_float("alpha")?;
-    let beta = node.get_attr_float("beta")?;
+    let alpha = node.get_attr("alpha")?;
+    let beta = node.get_attr("beta")?;
     Ok(Box::new(tractops::nn::ScaledTanh::new(alpha, beta)))
 }
 
@@ -250,18 +250,18 @@ element_map_with_params!(Shrink, [f16, f32, f64], { bias: f32, lambd: f32 },
 );
 
 pub fn shrink(node: &NodeProto) -> TractResult<Box<Op>> {
-    let bias = node.get_attr_opt_float("bias")?.unwrap_or(0.0);
-    let lambd = node.get_attr_opt_float("lambd")?.unwrap_or(0.5);
+    let bias = node.get_attr_opt("bias")?.unwrap_or(0.0);
+    let lambd = node.get_attr_opt("lambd")?.unwrap_or(0.5);
     Ok(Box::new(Shrink::new(bias, lambd)))
 }
 
 pub fn selu(node: &NodeProto) -> TractResult<Box<Op>> {
-    let alpha = node.get_attr_opt_float("alpha")?.unwrap_or(1.67326);
-    let gamma = node.get_attr_opt_float("gamma")?.unwrap_or(1.0507);
+    let alpha = node.get_attr_opt("alpha")?.unwrap_or(1.67326);
+    let gamma = node.get_attr_opt("gamma")?.unwrap_or(1.0507);
     Ok(Box::new(tractops::nn::Selu::new(alpha, gamma)))
 }
 
 pub fn thresholded_relu(node: &NodeProto) -> TractResult<Box<Op>> {
-    let alpha = node.get_attr_opt_float("alpha")?.unwrap_or(1.0);
+    let alpha = node.get_attr_opt("alpha")?.unwrap_or(1.);
     Ok(Box::new(tractops::nn::ThresholdedRelu::new(alpha)))
 }

--- a/onnx/src/ops/nn/mod.rs
+++ b/onnx/src/ops/nn/mod.rs
@@ -77,7 +77,13 @@ fn pad(node: &NodeProto) -> TractResult<PaddingSpec> {
         ));
     }
     Ok(node.get_attr_opt("auto_pad")?.and_try(|s| {
-        node.parse_str("auto_pad", s)
+        node.check_value("auto_pad", match s {
+            "NOTSET" => Ok(PaddingSpec::Valid),
+            "VALID" => Ok(PaddingSpec::Valid),
+            "SAME_UPPER" => Ok(PaddingSpec::SameUpper),
+            "SAME_LOWER" => Ok(PaddingSpec::SameLower),
+            _ => Err(s),
+        })
     })?.unwrap_or(PaddingSpec::Valid))
 }
 

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -125,6 +125,31 @@ impl<'a> AttrScalarType<'a> for f32 {
     }
 }
 
+pub trait AttrSliceType<'a>: 'a + Sized {
+    fn get_attr_opt_slice(node: &'a NodeProto, name: &str) -> TractResult<Option<&'a [Self]>>;
+}
+
+impl<'a> AttrSliceType<'a> for Vec<u8> {
+    fn get_attr_opt_slice(node: &'a NodeProto, name: &str) -> TractResult<Option<&'a [Self]>> {
+        node.get_attr_opt_with_type(name, AttributeProto_AttributeType::STRINGS)?
+            .and_ok(AttributeProto::get_strings)
+    }
+}
+
+impl<'a> AttrSliceType<'a> for i64 {
+    fn get_attr_opt_slice(node: &'a NodeProto, name: &str) -> TractResult<Option<&'a [Self]>> {
+        node.get_attr_opt_with_type(name, AttributeProto_AttributeType::INTS)?
+            .and_ok(AttributeProto::get_ints)
+    }
+}
+
+impl<'a> AttrSliceType<'a> for f32 {
+    fn get_attr_opt_slice(node: &'a NodeProto, name: &str) -> TractResult<Option<&'a [Self]>> {
+        node.get_attr_opt_with_type(name, AttributeProto_AttributeType::FLOATS)?
+            .and_ok(AttributeProto::get_floats)
+    }
+}
+
 impl NodeProto {
     pub fn expect<R: Reason>(&self, cond: bool, what: R) -> TractResult<()> {
         ensure!(

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -257,6 +257,18 @@ impl<'a> AttrTVecType<'a> for String {
     }
 }
 
+impl<'a> AttrTVecType<'a> for bool {
+    fn get_attr_opt_tvec(node: &'a NodeProto, name: &str) -> TractResult<Option<TVec<Self>>> {
+        let ints: Option<&[i64]> = AttrSliceType::get_attr_opt_slice(node, name)?;
+        ints.and_try(|ints| {
+            for int in ints.iter() {
+                node.expect_attr(name, *int == 0 || *int == 0, "list of booleans (0 or 1)")?;
+            }
+            Ok(ints.iter().map(|&x| x == 1).collect())
+        })
+    }
+}
+
 impl<'a> AttrTVecType<'a> for usize {
     fn get_attr_opt_tvec(node: &'a NodeProto, name: &str) -> TractResult<Option<TVec<Self>>> {
         let ints: Option<&[i64]> = AttrSliceType::get_attr_opt_slice(node, name)?;

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -230,17 +230,12 @@ impl NodeProto {
         }
     }
 
-    fn get_attr_opt(&self, name: &str) -> TractResult<Option<&AttributeProto>> {
-        Ok(self.get_attribute().iter().find(|a| a.get_name() == name))
-    }
-
     fn get_attr_opt_with_type(
         &self, name: &str, ty: AttributeProto_AttributeType,
     ) -> TractResult<Option<&AttributeProto>> {
-        let attr = if let Some(a) = self.get_attr_opt(name)? {
-            a
-        } else {
-            return Ok(None);
+        let attr = match self.get_attribute().iter().find(|a| a.get_name() == name) {
+            Some(attr) => attr,
+            _ => return Ok(None),
         };
         self.expect_attr(name, attr.get_field_type() == ty, || format!("{:?}", ty))?;
         Ok(Some(attr))

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -356,17 +356,6 @@ impl NodeProto {
         self.expect_attr_ok_or_else(name, self.get_attr_opt_str(name)?, "string")
     }
 
-    pub fn get_attr_opt_float(&self, name: &str) -> TractResult<Option<f32>> {
-        match self.get_attr_opt_with_type(name, AttributeProto_AttributeType::FLOAT)? {
-            Some(attr) => Ok(Some(attr.get_f())),
-            None => Ok(None),
-        }
-    }
-
-    pub fn get_attr_float(&self, name: &str) -> TractResult<f32> {
-        self.expect_attr_ok_or_else(name, self.get_attr_opt_float(name)?, "float")
-    }
-
     pub fn get_attr_opt_ints(&self, name: &str) -> TractResult<Option<&[i64]>> {
         match self.get_attr_opt_with_type(name, AttributeProto_AttributeType::INTS)? {
             Some(attr) => Ok(Some(attr.get_ints())),

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -3,6 +3,19 @@ use tract_core::*;
 
 use std::borrow::Cow;
 
+pub trait TryCollect<T, E>: Iterator<Item = Result<T, E>> + Sized {
+    #[must_use]
+    fn try_collect<B: Default + Extend<T>>(mut self) -> Result<B, E> {
+        let mut out = B::default();
+        while let Some(item) = self.next() {
+            out.extend(Some(item?));
+        }
+        Ok(out)
+    }
+}
+
+impl<T, E, I> TryCollect<T, E> for I where I: Iterator<Item = Result<T, E>> + Sized {}
+
 pub trait Reason {
     fn reason(&self) -> Cow<str>;
 }

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -301,15 +301,6 @@ impl NodeProto {
         }
     }
 
-    pub fn expect_attr_ok_or_else<T, R: Reason>(
-        &self, attr: &str, result: Option<T>, what: R,
-    ) -> TractResult<T> {
-        match result {
-            Some(v) => Ok(v),
-            None => Err(self.expect_attr(attr, false, what).unwrap_err()),
-        }
-    }
-
     fn get_attr_opt_with_type(
         &self, name: &str, ty: AttributeProto_AttributeType,
     ) -> TractResult<Option<&AttributeProto>> {

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -240,6 +240,13 @@ impl NodeProto {
         Ok(())
     }
 
+    pub fn expect_ok_or_else<T, R: Reason>(&self, result: Option<T>, what: R) -> TractResult<T> {
+        match result {
+            Some(v) => Ok(v),
+            None => Err(self.expect(false, what).unwrap_err()),
+        }
+    }
+
     pub fn expect_attr_ok_or_else<T, R: Reason>(
         &self, attr: &str, result: Option<T>, what: R,
     ) -> TractResult<T> {
@@ -260,6 +267,48 @@ impl NodeProto {
             format!("{}, got {}", ty, attr.get_field_type())
         })?;
         Ok(Some(attr))
+    }
+
+    pub fn get_attr_opt<'a, T>(&'a self, name: &str) -> TractResult<Option<T>>
+    where
+        T: AttrScalarType<'a>,
+    {
+        T::get_attr_opt_scalar(self, name)
+    }
+
+    pub fn get_attr<'a, T>(&'a self, name: &str) -> TractResult<T>
+    where
+        T: AttrScalarType<'a>,
+    {
+        self.expect_ok_or_else(self.get_attr_opt(name)?, || format!("attribute '{}'", name))
+    }
+
+    pub fn get_attr_opt_slice<'a, T>(&'a self, name: &str) -> TractResult<Option<&'a [T]>>
+    where
+        T: AttrSliceType<'a>,
+    {
+        T::get_attr_opt_slice(self, name)
+    }
+
+    pub fn get_attr_slice<'a, T>(&'a self, name: &str) -> TractResult<&'a [T]>
+    where
+        T: AttrSliceType<'a>,
+    {
+        self.expect_ok_or_else(self.get_attr_opt_slice(name)?, || format!("attribute '{}'", name))
+    }
+
+    pub fn get_attr_opt_tvec<'a, T>(&'a self, name: &str) -> TractResult<Option<TVec<T>>>
+    where
+        T: AttrTVecType<'a>,
+    {
+        T::get_attr_opt_tvec(self, name)
+    }
+
+    pub fn get_attr_tvec<'a, T>(&'a self, name: &str) -> TractResult<TVec<T>>
+    where
+        T: AttrTVecType<'a>,
+    {
+        self.expect_ok_or_else(self.get_attr_opt_tvec(name)?, || format!("attribute '{}'", name))
     }
 
     pub fn get_attr_opt_tensor(&self, name: &str) -> TractResult<Option<Tensor>> {

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -256,7 +256,9 @@ impl NodeProto {
             Some(attr) => attr,
             _ => return Ok(None),
         };
-        self.expect_attr(name, attr.get_field_type() == ty, || format!("{:?}", ty))?;
+        self.expect_attr(name, attr.get_field_type() == ty, || {
+            format!("{}, got {}", ty, attr.get_field_type())
+        })?;
         Ok(Some(attr))
     }
 

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -135,4 +135,16 @@ impl NodeProto {
             )
         })?)
     }
+
+    pub fn get_attr_usize_tvec(&self, name: &str) -> TractResult<TVec<usize>> {
+        let ints = self.get_attr_ints(name)?;
+        ensure!(
+            ints.iter().any(|&x| x < 0),
+            "Node {} ({}) expected a list of non-negatve ints in attribute '{}'",
+            self.get_name(),
+            self.get_op_type(),
+            name
+        );
+        Ok(ints.iter().map(|&x| x as _).collect())
+    }
 }

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -147,4 +147,20 @@ impl NodeProto {
         );
         Ok(ints.iter().map(|&x| x as _).collect())
     }
+
+    pub fn get_attr_opt_int_tvec(&self, name: &str) -> TractResult<Option<TVec<i64>>> {
+        self.get_attr_opt_ints(name)?.map(Into::into)
+    }
+
+    pub fn get_attr_int_tvec(&self, name: &str) -> TractResult<TVec<i64>> {
+        self.get_attr_ints(name)?.into()
+    }
+
+    pub fn get_attr_opt_float_tvec(&self, name: &str) -> TractResult<Option<TVec<f32>>> {
+        self.get_attr_opt_floats(name)?.map(Into::into)
+    }
+
+    pub fn get_attr_float_tvec(&self, name: &str) -> TractResult<TVec<f32>> {
+        self.get_attr_floats(name)?.into()
+    }
 }

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -311,17 +311,6 @@ impl NodeProto {
         self.expect_ok_or_else(self.get_attr_opt_tvec(name)?, || format!("attribute '{}'", name))
     }
 
-    pub fn get_attr_opt_tensor(&self, name: &str) -> TractResult<Option<Tensor>> {
-        match self.get_attr_opt_with_type(name, AttributeProto_AttributeType::TENSOR)? {
-            Some(attr) => Ok(Some(attr.get_t().tractify()?)),
-            None => Ok(None),
-        }
-    }
-
-    pub fn get_attr_tensor(&self, name: &str) -> TractResult<Tensor> {
-        self.expect_attr_ok_or_else(name, self.get_attr_opt_tensor(name)?, "tensor")
-    }
-
     pub fn get_attr_opt_str(&self, name: &str) -> TractResult<Option<&str>> {
         match self.get_attr_opt_with_type(name, AttributeProto_AttributeType::STRING)? {
             Some(attr) => Ok(Some(::std::str::from_utf8(attr.get_s())?)),

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -356,6 +356,20 @@ impl NodeProto {
         self.expect_ok_or_else(self.get_attr_opt_tvec(name)?, || format!("attribute '{}'", name))
     }
 
+    pub fn get_attr_opt_vec<'a, T>(&'a self, name: &str) -> TractResult<Option<Vec<T>>>
+    where
+        T: AttrTVecType<'a>,
+    {
+        Ok(self.get_attr_opt_tvec(name)?.map(TVec::into_vec))
+    }
+
+    pub fn get_attr_vec<'a, T>(&'a self, name: &str) -> TractResult<Vec<T>>
+    where
+        T: AttrTVecType<'a>,
+    {
+        self.get_attr_tvec(name).map(TVec::into_vec)
+    }
+
     pub fn get_attr_opt_ints(&self, name: &str) -> TractResult<Option<&[i64]>> {
         match self.get_attr_opt_with_type(name, AttributeProto_AttributeType::INTS)? {
             Some(attr) => Ok(Some(attr.get_ints())),

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -1,30 +1,73 @@
 use crate::pb::*;
 use tract_core::*;
 
+use std::borrow::Cow;
+
+pub trait Reason {
+    fn reason(&self) -> Cow<str>;
+}
+
+impl<'a> Reason for &'a str {
+    fn reason(&self) -> Cow<str> {
+        (*self).into()
+    }
+}
+
+impl<F> Reason for F
+where
+    F: Fn() -> String,
+{
+    fn reason(&self) -> Cow<str> {
+        self().into()
+    }
+}
+
 impl NodeProto {
+    pub fn expect<R: Reason>(&self, cond: bool, what: R) -> TractResult<()> {
+        ensure!(
+            cond,
+            "Node {} ({}): expected {}",
+            self.get_name(),
+            self.get_op_type(),
+            what.reason()
+        );
+        Ok(())
+    }
+
+    pub fn expect_attr<R: Reason>(&self, attr: &str, cond: bool, what: R) -> TractResult<()> {
+        ensure!(
+            cond,
+            "Node {} ({}), attribute '{}': expected {}",
+            self.get_name(),
+            self.get_op_type(),
+            attr,
+            what.reason()
+        );
+        Ok(())
+    }
+
+    pub fn expect_attr_ok_or_else<T, R: Reason>(
+        &self, attr: &str, result: Option<T>, what: R,
+    ) -> TractResult<T> {
+        match result {
+            Some(v) => Ok(v),
+            None => Err(self.expect_attr(attr, false, what).unwrap_err()),
+        }
+    }
+
     fn get_attr_opt(&self, name: &str) -> TractResult<Option<&AttributeProto>> {
         Ok(self.get_attribute().iter().find(|a| a.get_name() == name))
     }
 
     fn get_attr_opt_with_type(
-        &self,
-        name: &str,
-        ty: AttributeProto_AttributeType,
+        &self, name: &str, ty: AttributeProto_AttributeType,
     ) -> TractResult<Option<&AttributeProto>> {
         let attr = if let Some(a) = self.get_attr_opt(name)? {
             a
         } else {
             return Ok(None);
         };
-        if attr.get_field_type() != ty {
-            bail!(
-                "Node {} ({}) expected attribute {} to be {:?}",
-                self.get_name(),
-                self.get_op_type(),
-                name,
-                ty
-            )
-        }
+        self.expect_attr(name, attr.get_field_type() == ty, || format!("{:?}", ty))?;
         Ok(Some(attr))
     }
 
@@ -36,14 +79,7 @@ impl NodeProto {
     }
 
     pub fn get_attr_tensor(&self, name: &str) -> TractResult<Tensor> {
-        Ok(self.get_attr_opt_tensor(name)?.ok_or_else(|| {
-            format!(
-                "Node {} ({}) expected tensor attribute '{}'",
-                self.get_name(),
-                self.get_op_type(),
-                name
-            )
-        })?)
+        self.expect_attr_ok_or_else(name, self.get_attr_opt_tensor(name)?, "tensor")
     }
 
     pub fn get_attr_opt_str(&self, name: &str) -> TractResult<Option<&str>> {
@@ -54,14 +90,7 @@ impl NodeProto {
     }
 
     pub fn get_attr_str(&self, name: &str) -> TractResult<&str> {
-        Ok(self.get_attr_opt_str(name)?.ok_or_else(|| {
-            format!(
-                "Node {} ({}) expected string attribute '{}'",
-                self.get_name(),
-                self.get_op_type(),
-                name
-            )
-        })?)
+        self.expect_attr_ok_or_else(name, self.get_attr_opt_str(name)?, "string")
     }
 
     pub fn get_attr_opt_int(&self, name: &str) -> TractResult<Option<i64>> {
@@ -72,14 +101,7 @@ impl NodeProto {
     }
 
     pub fn get_attr_int(&self, name: &str) -> TractResult<i64> {
-        Ok(self.get_attr_opt_int(name)?.ok_or_else(|| {
-            format!(
-                "Node {} ({}) expected int attribute '{}'",
-                self.get_name(),
-                self.get_op_type(),
-                name
-            )
-        })?)
+        self.expect_attr_ok_or_else(name, self.get_attr_opt_int(name)?, "int")
     }
 
     pub fn get_attr_opt_float(&self, name: &str) -> TractResult<Option<f32>> {
@@ -90,14 +112,7 @@ impl NodeProto {
     }
 
     pub fn get_attr_float(&self, name: &str) -> TractResult<f32> {
-        Ok(self.get_attr_opt_float(name)?.ok_or_else(|| {
-            format!(
-                "Node {} ({}) expected float attribute '{}'",
-                self.get_name(),
-                self.get_op_type(),
-                name
-            )
-        })?)
+        self.expect_attr_ok_or_else(name, self.get_attr_opt_float(name)?, "float")
     }
 
     pub fn get_attr_opt_ints(&self, name: &str) -> TractResult<Option<&[i64]>> {
@@ -108,14 +123,7 @@ impl NodeProto {
     }
 
     pub fn get_attr_ints(&self, name: &str) -> TractResult<&[i64]> {
-        Ok(self.get_attr_opt_ints(name)?.ok_or_else(|| {
-            format!(
-                "Node {} ({}) expected list of ints attribute '{}'",
-                self.get_name(),
-                self.get_op_type(),
-                name
-            )
-        })?)
+        self.expect_attr_ok_or_else(name, self.get_attr_opt_ints(name)?, "list of ints")
     }
 
     pub fn get_attr_opt_floats(&self, name: &str) -> TractResult<Option<&[f32]>> {
@@ -126,41 +134,30 @@ impl NodeProto {
     }
 
     pub fn get_attr_floats(&self, name: &str) -> TractResult<&[f32]> {
-        Ok(self.get_attr_opt_floats(name)?.ok_or_else(|| {
-            format!(
-                "Node {} ({}) expected list of floats attribute '{}'",
-                self.get_name(),
-                self.get_op_type(),
-                name
-            )
-        })?)
+        self.expect_attr_ok_or_else(name, self.get_attr_opt_floats(name)?, "list of floats")
     }
 
     pub fn get_attr_usize_tvec(&self, name: &str) -> TractResult<TVec<usize>> {
         let ints = self.get_attr_ints(name)?;
-        ensure!(
-            ints.iter().any(|&x| x < 0),
-            "Node {} ({}) expected a list of non-negatve ints in attribute '{}'",
-            self.get_name(),
-            self.get_op_type(),
-            name
-        );
+        for i in ints.iter() {
+            self.expect_attr(name, *i >= 0, "list of non-negative ints")?;
+        }
         Ok(ints.iter().map(|&x| x as _).collect())
     }
 
     pub fn get_attr_opt_int_tvec(&self, name: &str) -> TractResult<Option<TVec<i64>>> {
-        self.get_attr_opt_ints(name)?.map(Into::into)
+        Ok(self.get_attr_opt_ints(name)?.map(Into::into))
     }
 
     pub fn get_attr_int_tvec(&self, name: &str) -> TractResult<TVec<i64>> {
-        self.get_attr_ints(name)?.into()
+        Ok(self.get_attr_ints(name)?.into())
     }
 
     pub fn get_attr_opt_float_tvec(&self, name: &str) -> TractResult<Option<TVec<f32>>> {
-        self.get_attr_opt_floats(name)?.map(Into::into)
+        Ok(self.get_attr_opt_floats(name)?.map(Into::into))
     }
 
     pub fn get_attr_float_tvec(&self, name: &str) -> TractResult<TVec<f32>> {
-        self.get_attr_floats(name)?.into()
+        Ok(self.get_attr_floats(name)?.into())
     }
 }

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -356,17 +356,6 @@ impl NodeProto {
         self.expect_ok_or_else(self.get_attr_opt_tvec(name)?, || format!("attribute '{}'", name))
     }
 
-    pub fn get_attr_opt_str(&self, name: &str) -> TractResult<Option<&str>> {
-        match self.get_attr_opt_with_type(name, AttributeProto_AttributeType::STRING)? {
-            Some(attr) => Ok(Some(::std::str::from_utf8(attr.get_s())?)),
-            None => Ok(None),
-        }
-    }
-
-    pub fn get_attr_str(&self, name: &str) -> TractResult<&str> {
-        self.expect_attr_ok_or_else(name, self.get_attr_opt_str(name)?, "string")
-    }
-
     pub fn get_attr_opt_ints(&self, name: &str) -> TractResult<Option<&[i64]>> {
         match self.get_attr_opt_with_type(name, AttributeProto_AttributeType::INTS)? {
             Some(attr) => Ok(Some(attr.get_ints())),

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -4,8 +4,8 @@ use tract_core::*;
 use num_traits::{AsPrimitive, Bounded};
 
 use std::borrow::Cow;
-use std::fmt::{self, Display};
-use std::str::{self, FromStr};
+use std::fmt::{self, Debug, Display};
+use std::str;
 
 pub trait TryCollect<T, E>: Iterator<Item = Result<T, E>> + Sized {
     #[must_use]
@@ -328,14 +328,11 @@ impl NodeProto {
         self.expect_ok_or_else(self.get_attr_opt(name)?, || format!("attribute '{}'", name))
     }
 
-    pub fn parse_str<T>(&self, attr: &str, s: &str) -> TractResult<T>
-    where
-        T: FromStr,
-    {
-        if let Ok(v) = T::from_str(s) {
-            return Ok(v);
+    pub fn check_value<T, V: Debug>(&self, attr: &str, value: Result<T, V>) -> TractResult<T> {
+        match value {
+            Ok(value) => Ok(value),
+            Err(err) => self.bail_attr(attr, &format!("unexpected value: {:?}", err)),
         }
-        self.bail_attr(attr, &format!("unexpected value: {:?}", s))
     }
 
     pub fn get_attr_opt_slice<'a, T>(&'a self, name: &str) -> TractResult<Option<&'a [T]>>

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -147,6 +147,30 @@ impl<'a> AttrScalarType<'a> for usize {
     }
 }
 
+macro_rules! impl_attr_scalar_type_int {
+    ($ty:ident) => {
+        impl<'a> AttrScalarType<'a> for $ty {
+            fn get_attr_opt_scalar(node: &'a NodeProto, name: &str) -> TractResult<Option<Self>> {
+                let int: Option<i64> = AttrScalarType::get_attr_opt_scalar(node, name)?;
+                int.and_try(|int| {
+                    node.expect_attr(name, int <= $ty::max_value() as i64, || {
+                        format!("int <= {}", $ty::max_value())
+                    })?;
+                    node.expect_attr(name, int >= $ty::min_value() as i64, || {
+                        format!("int >= {}", $ty::min_value())
+                    })?;
+                    Ok(int as $ty)
+                })
+            }
+        }
+    };
+}
+
+impl_attr_scalar_type_int!(i8);
+impl_attr_scalar_type_int!(i16);
+impl_attr_scalar_type_int!(i32);
+impl_attr_scalar_type_int!(isize);
+
 impl<'a> AttrScalarType<'a> for f32 {
     fn get_attr_opt_scalar(node: &'a NodeProto, name: &str) -> TractResult<Option<Self>> {
         node.get_attr_opt_with_type(name, AttributeProto_AttributeType::FLOAT)?

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -356,17 +356,6 @@ impl NodeProto {
         self.expect_attr_ok_or_else(name, self.get_attr_opt_str(name)?, "string")
     }
 
-    pub fn get_attr_opt_int(&self, name: &str) -> TractResult<Option<i64>> {
-        match self.get_attr_opt_with_type(name, AttributeProto_AttributeType::INT)? {
-            Some(attr) => Ok(Some(attr.get_i())),
-            None => Ok(None),
-        }
-    }
-
-    pub fn get_attr_int(&self, name: &str) -> TractResult<i64> {
-        self.expect_attr_ok_or_else(name, self.get_attr_opt_int(name)?, "int")
-    }
-
     pub fn get_attr_opt_float(&self, name: &str) -> TractResult<Option<f32>> {
         match self.get_attr_opt_with_type(name, AttributeProto_AttributeType::FLOAT)? {
             Some(attr) => Ok(Some(attr.get_f())),

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -35,6 +35,39 @@ where
     }
 }
 
+trait OptionExt {
+    type Item;
+
+    fn and_try<F, T>(self, f: F) -> TractResult<Option<T>>
+    where
+        F: Fn(Self::Item) -> TractResult<T>;
+
+    fn and_ok<F, T>(self, f: F) -> TractResult<Option<T>>
+    where
+        F: Fn(Self::Item) -> T;
+}
+
+impl<A> OptionExt for Option<A> {
+    type Item = A;
+
+    fn and_try<F, T>(self, f: F) -> TractResult<Option<T>>
+    where
+        F: Fn(Self::Item) -> TractResult<T>,
+    {
+        match self {
+            Some(attr) => f(attr).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn and_ok<F, T>(self, f: F) -> TractResult<Option<T>>
+    where
+        F: Fn(Self::Item) -> T,
+    {
+        Ok(self.map(f))
+    }
+}
+
 impl NodeProto {
     pub fn expect<R: Reason>(&self, cond: bool, what: R) -> TractResult<()> {
         ensure!(

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -388,23 +388,4 @@ impl NodeProto {
     {
         self.get_attr_tvec(name).map(TVec::into_vec)
     }
-
-    pub fn get_attr_opt_floats(&self, name: &str) -> TractResult<Option<&[f32]>> {
-        match self.get_attr_opt_with_type(name, AttributeProto_AttributeType::FLOATS)? {
-            Some(attr) => Ok(Some(attr.get_floats())),
-            None => Ok(None),
-        }
-    }
-
-    pub fn get_attr_floats(&self, name: &str) -> TractResult<&[f32]> {
-        self.expect_attr_ok_or_else(name, self.get_attr_opt_floats(name)?, "list of floats")
-    }
-
-    pub fn get_attr_opt_float_tvec(&self, name: &str) -> TractResult<Option<TVec<f32>>> {
-        Ok(self.get_attr_opt_floats(name)?.map(Into::into))
-    }
-
-    pub fn get_attr_float_tvec(&self, name: &str) -> TractResult<TVec<f32>> {
-        Ok(self.get_attr_floats(name)?.into())
-    }
 }

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -2,6 +2,7 @@ use crate::pb::*;
 use tract_core::*;
 
 use std::borrow::Cow;
+use std::fmt::{self, Display};
 use std::str;
 
 pub trait TryCollect<T, E>: Iterator<Item = Result<T, E>> + Sized {
@@ -66,6 +67,24 @@ impl<A> OptionExt for Option<A> {
         F: Fn(Self::Item) -> T,
     {
         Ok(self.map(f))
+    }
+}
+
+impl Display for AttributeProto_AttributeType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            AttributeProto_AttributeType::INT => "int",
+            AttributeProto_AttributeType::FLOAT => "float",
+            AttributeProto_AttributeType::TENSOR => "tensor",
+            AttributeProto_AttributeType::STRING => "string",
+            AttributeProto_AttributeType::INTS => "list of ints",
+            AttributeProto_AttributeType::FLOATS => "list of floats",
+            AttributeProto_AttributeType::TENSORS => "list of tensors",
+            AttributeProto_AttributeType::STRINGS => "list of strings",
+            AttributeProto_AttributeType::GRAPH => "graph",
+            AttributeProto_AttributeType::GRAPHS => "graphs",
+            _ => "<undefined>",
+        })
     }
 }
 

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -127,6 +127,16 @@ impl<'a> AttrScalarType<'a> for i64 {
     }
 }
 
+impl<'a> AttrScalarType<'a> for bool {
+    fn get_attr_opt_scalar(node: &'a NodeProto, name: &str) -> TractResult<Option<Self>> {
+        let int: Option<i64> = AttrScalarType::get_attr_opt_scalar(node, name)?;
+        int.and_try(|int| {
+            node.expect_attr(name, int == 0 || int == 1, "boolean (0 or 1)")?;
+            Ok(int == 1)
+        })
+    }
+}
+
 impl<'a> AttrScalarType<'a> for usize {
     fn get_attr_opt_scalar(node: &'a NodeProto, name: &str) -> TractResult<Option<Self>> {
         let int: Option<i64> = AttrScalarType::get_attr_opt_scalar(node, name)?;

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -389,17 +389,6 @@ impl NodeProto {
         self.get_attr_tvec(name).map(TVec::into_vec)
     }
 
-    pub fn get_attr_opt_ints(&self, name: &str) -> TractResult<Option<&[i64]>> {
-        match self.get_attr_opt_with_type(name, AttributeProto_AttributeType::INTS)? {
-            Some(attr) => Ok(Some(attr.get_ints())),
-            None => Ok(None),
-        }
-    }
-
-    pub fn get_attr_ints(&self, name: &str) -> TractResult<&[i64]> {
-        self.expect_attr_ok_or_else(name, self.get_attr_opt_ints(name)?, "list of ints")
-    }
-
     pub fn get_attr_opt_floats(&self, name: &str) -> TractResult<Option<&[f32]>> {
         match self.get_attr_opt_with_type(name, AttributeProto_AttributeType::FLOATS)? {
             Some(attr) => Ok(Some(attr.get_floats())),
@@ -409,22 +398,6 @@ impl NodeProto {
 
     pub fn get_attr_floats(&self, name: &str) -> TractResult<&[f32]> {
         self.expect_attr_ok_or_else(name, self.get_attr_opt_floats(name)?, "list of floats")
-    }
-
-    pub fn get_attr_usize_tvec(&self, name: &str) -> TractResult<TVec<usize>> {
-        let ints = self.get_attr_ints(name)?;
-        for i in ints.iter() {
-            self.expect_attr(name, *i >= 0, "list of non-negative ints")?;
-        }
-        Ok(ints.iter().map(|&x| x as _).collect())
-    }
-
-    pub fn get_attr_opt_int_tvec(&self, name: &str) -> TractResult<Option<TVec<i64>>> {
-        Ok(self.get_attr_opt_ints(name)?.map(Into::into))
-    }
-
-    pub fn get_attr_int_tvec(&self, name: &str) -> TractResult<TVec<i64>> {
-        Ok(self.get_attr_ints(name)?.into())
     }
 
     pub fn get_attr_opt_float_tvec(&self, name: &str) -> TractResult<Option<TVec<f32>>> {

--- a/onnx/src/pb_helpers.rs
+++ b/onnx/src/pb_helpers.rs
@@ -117,4 +117,22 @@ impl NodeProto {
             )
         })?)
     }
+
+    pub fn get_attr_opt_floats(&self, name: &str) -> TractResult<Option<&[f32]>> {
+        match self.get_attr_opt_with_type(name, AttributeProto_AttributeType::FLOATS)? {
+            Some(attr) => Ok(Some(attr.get_floats())),
+            None => Ok(None),
+        }
+    }
+
+    pub fn get_attr_floats(&self, name: &str) -> TractResult<&[f32]> {
+        Ok(self.get_attr_opt_floats(name)?.ok_or_else(|| {
+            format!(
+                "Node {} ({}) expected list of floats attribute '{}'",
+                self.get_name(),
+                self.get_op_type(),
+                name
+            )
+        })?)
+    }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+use_small_heuristics = "Max"
+use_field_init_shorthand = true
+use_try_shorthand = true
+empty_item_single_line = true
+edition = "2018"
+unstable_features = true
+fn_args_density = "Compressed"


### PR DESCRIPTION
As I've started writing pb config parser for tree-ml nodes, I figured it might be helpful to refactor protobuf getters a bit.

This brings an easier way to parse all kinds of ints, vecs/tvecs etc, with less boilerplate.

It's not just a refactor, a few functional changes as well, stricter validation:
- Trying to convert an int64 pb value into an integer type that can't contain it would now raise a descriptive error (especially with all the `usize` values); this also works with vecs/tvecs. In the current version, it would happily convert an `-1i64 as usize`; here, it would complain loudly. Ideally, all occurences of `as usize` in the codebase should also be double-checked.
- Booleans are now restricted to 0 and 1 (this was also inconsistent, in some places it was checking for 1, in some places - for non-zero, etc).

It's still a bit of a mess, with a whole bunch of random stuff in pb_helpers, but it's all internal so should be all good for now.

Upd: ouch, rebasing this on #72 and #73 would be a bit painful... :)