### PR TITLE
Initial support for AddV2

### DIFF
--- a/onnx/src/ops/math.rs
+++ b/onnx/src/ops/math.rs
@@ -7,6 +7,7 @@ use tract_core::ops::binary::Nary;
 
 pub fn register_all_ops(reg: &mut OnnxOpRegister) {
     reg.insert("Add", |_, _| Ok((Box::new(tractops::math::add::bin()), vec![])));
+    reg.insert("AddV2", |_, _| Ok((Box::new(tractops::math::add::bin()), vec![])));
     reg.insert("Sub", |_, _| Ok((Box::new(tractops::math::sub::bin()), vec![])));
     reg.insert("Mul", |_, _| Ok((Box::new(tractops::math::mul::bin()), vec![])));
     reg.insert("Div", |_, _| Ok((Box::new(tractops::math::div::bin()), vec![])));

--- a/tensorflow/src/ops/math.rs
+++ b/tensorflow/src/ops/math.rs
@@ -11,6 +11,7 @@ pub fn register_all_ops(reg: &mut TfOpRegister) {
     reg.insert("Abs", |_, _| Ok(Box::new(tractops::math::abs())));
     reg.insert("Add", |_, _| Ok(Box::new(tractops::math::add::bin())));
     reg.insert("AddN", add_n);
+    reg.insert("AddV2", |_, _| Ok(Box::new(tractops::math::add::bin())));
     reg.insert("BiasAdd", |_, _| Ok(Box::new(tractops::math::add::bin())));
     reg.insert("Ceil", |_, _| Ok(Box::new(tractops::math::ceil())));
     reg.insert("Div", |_, _| Ok(Box::new(tractops::math::div::bin())));


### PR DESCRIPTION
AddV2 is a new operator that Tensorflow 2 likes to emit. As per the documentation it is identical to Add. Compare https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/add-v2 to https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/add ...

I don't understand what the point of this op is, but this simple workaround fixes my problem :)

Could also of course duplicate the functions, but until I can find information about what makes AddV2 different, I think this is better...

Fixes #180 