### PR TITLE
Checking os == ios instead of family == ios

### DIFF
--- a/linalg/arm64/arm64simd/arm64simd_smmm_8x8.tmpl
+++ b/linalg/arm64/arm64simd/arm64simd_smmm_8x8.tmpl
@@ -18,7 +18,7 @@
 
 .text
 .align 4
-{% if family == "ios" %}
+{% if os == "ios" %}
     .global _arm64simd_smmm_8x8
     _arm64simd_smmm_8x8:
 {% else %}


### PR DESCRIPTION
Came across this bug trying to compile for iOS.

I wasn't able to link to _arm64simd_smmm_8x8 since ios is not a valid target_family. Changed to check against target_os instead. (assuming this is the intended check and not family == unix)
https://doc.rust-lang.org/reference/conditional-compilation.html#target_os