### PR TITLE
Upgrade liquid to 0.20

### DIFF
--- a/linalg/Cargo.toml
+++ b/linalg/Cargo.toml
@@ -24,7 +24,7 @@ dyn-clone = "1"
 
 [build-dependencies]
 cc = "1.0"
-liquid = "0.19"
+liquid = "0.20"
 unicode-normalization = "0.1"
 smallvec = "1"
 


### PR DESCRIPTION
The old version depended on an old syn version that we don't want in our deps.

By the way, was wondering why in the world tract would use a templating engine - a macro assembler was an unexpected but clever usecase!