### PR TITLE
Move env_logger to [dev-dependencies] wherever possible.

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,7 +30,6 @@ serde = { "version" = "1.0", optional = true }
 serde_derive = { "version" = "1.0", optional = true }
 smallvec = "1"
 tract-linalg = { path = "../linalg" }
-unsafe_unwrap = "0.1.0"
 
 [features]
 default = [ ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -31,7 +31,6 @@ serde_derive = { "version" = "1.0", optional = true }
 smallvec = "1"
 tract-linalg = { path = "../linalg" }
 unsafe_unwrap = "0.1.0"
-env_logger = "0.7"
 
 [features]
 default = [ ]
@@ -40,6 +39,7 @@ default = [ ]
 [dev-dependencies]
 criterion = "0.3"
 proptest = "0.9"
+env_logger = "0.7"
 
 [[bench]]
 name = "conv_direct_vs_im2col"

--- a/harness/core-proptest-pulse/Cargo.toml
+++ b/harness/core-proptest-pulse/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 tract-hir = { path = "../../hir" }
-env_logger = "0.7.0"
 
 [dev-dependencies]
 proptest = "0.9"
+env_logger = "0.7"

--- a/harness/onnx-test-suite/Cargo.toml
+++ b/harness/onnx-test-suite/Cargo.toml
@@ -6,11 +6,13 @@ edition = "2018"
 
 [dependencies]
 bytes = "0.5"
-env_logger = "0.7"
 fs2 = "0.4"
 log = "0.4.6"
 prost = "0.6"
 tract-onnx = { path = "../../onnx" }
+
+[dev-dependencies]
+env_logger = "0.7"
 
 [build-dependencies]
 fs2 = "0.4"

--- a/harness/tf-moz-deepspeech/Cargo.toml
+++ b/harness/tf-moz-deepspeech/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 edition = "2018"
 
 [dependencies]
-env_logger = "0.7"
 log = "0.4"
 tract-tensorflow = { path = "../../tensorflow" }
+
+[dev-dependencies]
+env_logger = "0.7"

--- a/harness/tf-moz-deepspeech/src/lib.rs
+++ b/harness/tf-moz-deepspeech/src/lib.rs
@@ -10,7 +10,6 @@ use std::str::FromStr;
 
 use tract_tensorflow::prelude::*;
 
-#[allow(dead_code)]
 #[cfg(test)]
 fn setup_test_logger() {
     let _ = env_logger::Builder::from_env("TRACT_LOG").try_init();

--- a/harness/tf-moz-deepspeech/src/lib.rs
+++ b/harness/tf-moz-deepspeech/src/lib.rs
@@ -11,6 +11,7 @@ use std::str::FromStr;
 use tract_tensorflow::prelude::*;
 
 #[allow(dead_code)]
+#[cfg(test)]
 fn setup_test_logger() {
     let _ = env_logger::Builder::from_env("TRACT_LOG").try_init();
 }

--- a/hir/Cargo.toml
+++ b/hir/Cargo.toml
@@ -15,7 +15,9 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 derive-new = "0.5"
-env_logger = "0.7"
 itertools = "0.8"
 log = "0.4"
 tract-core = { path = "../core" }
+
+[dev-dependencies]
+env_logger = "0.7"

--- a/kaldi/src/model.rs
+++ b/kaldi/src/model.rs
@@ -225,11 +225,11 @@ impl Framework<KaldiProtoModel> for Kaldi {
                         let op = match self.op_register.0.get(&*component.klass) {
                             Some(builder) => (builder)(&ctx, name)?,
                             None => {
-                                (Box::new(tract_hir::ops::unimpl::UnimplementedOp::new(
+                                Box::new(tract_hir::ops::unimpl::UnimplementedOp::new(
                                     1,
                                     component.klass.to_string(),
                                     format!("{:?}", line),
-                                )))
+                                ))
                             }
                         };
                         let id = model.add_node(


### PR DESCRIPTION
And a tiny warning fix.

Prevents the env_logger dev dependency from leaking out to crates depending on tract.