### PR TITLE
Add with_ convenience methods, add into_runnable

### DIFF
--- a/core/src/model/compact.rs
+++ b/core/src/model/compact.rs
@@ -25,7 +25,7 @@ where
             for (ix, &o) in outlets.iter().enumerate() {
                 map.insert(OutletId::new(old_id, ix), o);
                 if let Some(label) = old.outlet_label(OutletId::new(old_id, ix)) {
-                    new.set_outlet_label(o, label.to_string());
+                    new.set_outlet_label(o, label.to_string())?;
                 }
             }
             if old.input_outlets()?.contains(&OutletId::new(old_node.id, 0)) {

--- a/core/src/model/mod.rs
+++ b/core/src/model/mod.rs
@@ -135,7 +135,7 @@ pub type TypedSimplePlan<M> = SimplePlan<TypedFact, Box<dyn TypedOp>, M>;
 pub type TypedSimpleState<M, P> = SimpleState<TypedFact, Box<dyn TypedOp>, M, P>;
 
 /// A model with determined types and shapes, where constant have been
-/// eleminated from the graph.
+/// eliminated from the graph.
 pub type NormalizedModel = ModelImpl<NormalizedFact, Box<dyn TypedOp>>;
 /// A Node for NormalizedModel.
 pub type NormalizedNode = BaseNode<NormalizedFact, Box<dyn TypedOp>>;
@@ -145,6 +145,9 @@ pub type NormalizedModelPatch = ModelPatch<NormalizedFact, Box<dyn TypedOp>>;
 pub type NormalizedSimplePlan<M> = SimplePlan<NormalizedFact, Box<dyn TypedOp>, M>;
 /// An execution state for TypedModel.
 pub type NormalizedSimpleState<M, P> = SimpleState<NormalizedFact, Box<dyn TypedOp>, M, P>;
+
+/// A runnable model with fixed inputs and outputs.
+pub type RunnableModel<F, O, M> = SimplePlan<F, O, M>;
 
 impl TypedModel {
     pub fn signature(&self) -> u64 {

--- a/core/src/model/model.rs
+++ b/core/src/model/model.rs
@@ -424,6 +424,7 @@ where
         Ok(())
     }
 
+    /// Converts the model into a `RunnableModel` which fixes the inputs and outputs and allows passing data through the model.
     pub fn into_runnable(self) -> TractResult<RunnableModel<F, O, Self>> {
         SimplePlan::new(self)
     }

--- a/core/src/model/model.rs
+++ b/core/src/model/model.rs
@@ -117,6 +117,12 @@ where
         Ok(())
     }
 
+    /// Change model inputs and return `self`.
+    pub fn with_input_outlets(mut self, inputs: &[OutletId]) -> TractResult<Self> {
+        self.set_input_outlets(inputs)?;
+        Ok(self)
+    }
+
     /// Set model inputs by the node name.
     pub fn set_input_names(
         &mut self,
@@ -131,6 +137,15 @@ where
         }
         self.inputs = ids;
         Ok(())
+    }
+
+    /// Set model inputs by the node name and return `self`.
+    pub fn with_input_names(
+        mut self,
+        inputs: impl IntoIterator<Item = impl AsRef<str>>
+    ) -> TractResult<Self> {
+        self.set_input_names(inputs)?;
+        Ok(self)
     }
 
     /// Get the `ix`-th input tensor type information.
@@ -149,6 +164,12 @@ where
     pub fn set_input_fact(&mut self, input: usize, fact: F) -> TractResult<()> {
         let outlet = self.inputs[input];
         self.set_outlet_fact(outlet, fact)
+    }
+
+    /// Set the `ix`-th input tensor type information and return `self`.
+    pub fn with_input_fact(mut self, input: usize, fact: F) -> TractResult<Self> {
+        self.set_input_fact(input, fact)?;
+        Ok(self)
     }
 
     // Outputs
@@ -181,6 +202,12 @@ where
         Ok(())
     }
 
+    /// Change model outputs and return `self`.
+    pub fn with_output_outlets(mut self, outputs: &[OutletId]) -> TractResult<Self> {
+        self.set_output_outlets(outputs)?;
+        Ok(self)
+    }
+
     /// Set model outputs by node names.
     pub fn set_output_names(
         &mut self,
@@ -192,6 +219,15 @@ where
             .collect::<TractResult<_>>()?;
         self.outputs = ids;
         Ok(())
+    }
+
+    /// Set model outputs by node names and return `self`.
+    pub fn with_output_names(
+        mut self,
+        outputs: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> TractResult<Self> {
+        self.set_output_names(outputs)?;
+        Ok(self)
     }
 
     /// Get the `ix`-th input tensor type information.
@@ -210,6 +246,12 @@ where
     pub fn set_output_fact(&mut self, output: usize, fact: F) -> TractResult<()> {
         let outlet = self.outputs[output];
         self.set_outlet_fact(outlet, fact)
+    }
+
+    /// Set the `ix`-th output tensor type information and return `self`.
+    pub fn with_output_fact(mut self, output: usize, fact: F) -> TractResult<Self> {
+        self.set_output_fact(output, fact)?;
+        Ok(self)
     }
 
     // nodes and their facts
@@ -314,6 +356,12 @@ where
         Ok(())
     }
 
+    /// Set tensor information for a single outlet and return `self`.
+    pub fn with_outlet_fact(mut self, outlet: OutletId, fact: F) -> TractResult<Self> {
+        self.set_outlet_fact(outlet, fact)?;
+        Ok(self)
+    }
+
     // outlet labels
 
     /// Get label for an outlet.
@@ -322,8 +370,15 @@ where
     }
 
     /// Set label for an outlet.
-    pub fn set_outlet_label(&mut self, outlet: OutletId, label: String) {
+    pub fn set_outlet_label(&mut self, outlet: OutletId, label: String) -> TractResult<()> {
         self.outlet_labels.insert(outlet, label);
+        Ok(())
+    }
+
+    /// Set label for an outlet and return `self`.
+    pub fn with_outlet_label(mut self, outlet: OutletId, label: String) -> TractResult<Self> {
+        self.set_outlet_label(outlet, label)?;
+        Ok(self)
     }
 
     /// Find outlet by label.

--- a/core/src/model/model.rs
+++ b/core/src/model/model.rs
@@ -368,6 +368,10 @@ where
         }
         Ok(())
     }
+
+    pub fn into_runnable(self) -> TractResult<RunnableModel<F, O, Self>> {
+        SimplePlan::new(self)
+    }
 }
 
 impl<F, O> Model for ModelImpl<F, O>

--- a/core/src/model/patch.rs
+++ b/core/src/model/patch.rs
@@ -233,7 +233,7 @@ where
                 }
             }
             if let Some(label) = target.outlet_label(outlet).map(|s| s.to_string()) {
-                target.set_outlet_label(fixed_by, label);
+                target.set_outlet_label(fixed_by, label)?;
             }
         }
         debug_assert_eq!(target.input_outlets()?.len(), prior_target_inputs);

--- a/core/src/model/translator.rs
+++ b/core/src/model/translator.rs
@@ -38,7 +38,7 @@ where
             for (ix, outlet) in outlets.into_iter().enumerate() {
                 mapping.insert(OutletId::new(node.id, ix), outlet);
                 if let Some(label) = source.outlet_label(OutletId::new(node.id, ix)) {
-                    target.set_outlet_label(outlet, label.to_string());
+                    target.set_outlet_label(outlet, label.to_string())?;
                 }
             }
         }

--- a/examples/jupyter-keras-tract/src/main.rs
+++ b/examples/jupyter-keras-tract/src/main.rs
@@ -3,10 +3,14 @@ use tract_tensorflow::prelude::*;
 
 fn main() -> TractResult<()> {
     let model = tensorflow()
-        .model_for_path("./my_model.pb")? // load the model
-        .with_input_fact(0, InferenceFact::dt_shape(f32::datum_type(), tvec![10, 100]))? // specify input type and shape
-        .into_optimized()? // optimize graph
-        .into_runnable()?; // make the model runnable and fix its inputs and outputs
+        // load the model
+        .model_for_path("./my_model.pb")?
+        // specify input type and shape
+        .with_input_fact(0, InferenceFact::dt_shape(f32::datum_type(), tvec![10, 100]))?
+        // optimize graph
+        .into_optimized()?
+        // make the model runnable and fix its inputs and outputs
+        .into_runnable()?;
 
     // Generate some input data for the model
     let mut rng = thread_rng();

--- a/examples/jupyter-keras-tract/src/main.rs
+++ b/examples/jupyter-keras-tract/src/main.rs
@@ -2,23 +2,19 @@ use rand::*;
 use tract_tensorflow::prelude::*;
 
 fn main() -> TractResult<()> {
-    // load the model
-    let mut model = tensorflow().model_for_path("./my_model.pb")?;
-
-    // specify input type and shape
-    model.set_input_fact(0, InferenceFact::dt_shape(f32::datum_type(), tvec![10, 100]))?;
-    let model = model.into_optimized()?;
+    let model = tensorflow()
+        .model_for_path("./my_model.pb")? // load the model
+        .with_input_fact(0, InferenceFact::dt_shape(f32::datum_type(), tvec![10, 100]))? // specify input type and shape
+        .into_optimized()? // optimize graph
+        .into_runnable()?; // make the model runnable and fix its inputs and outputs
 
     // Generate some input data for the model
     let mut rng = thread_rng();
     let vals: Vec<_> = (0..1000).map(|_| rng.gen::<f32>()).collect();
     let input = tract_ndarray::arr1(&vals).into_shape((10, 100)).unwrap();
 
-    // Make an execution plan for the model
-    let plan = SimplePlan::new(&model).unwrap();
-
     // Input the generated data into the model
-    let result = plan.run(tvec![input.into()]).unwrap();
+    let result = model.run(tvec![input.into()]).unwrap();
     let to_show = result[0].to_array_view::<f32>()?;
     println!("result: {:?}", to_show);
     Ok(())

--- a/examples/pytorch-resnet/src/main.rs
+++ b/examples/pytorch-resnet/src/main.rs
@@ -3,10 +3,14 @@ use tract_onnx::prelude::*;
 
 fn main() -> TractResult<()> {
     let model = tract_onnx::onnx()
-        .model_for_path("resnet.onnx")? // load the model
-        .with_input_fact(0, InferenceFact::dt_shape(f32::datum_type(), tvec!(1, 3, 224, 224)))? // specify input type and shape
-        .into_optimized()? // optimize the model
-        .into_runnable()?; // make the model runnable and fix its inputs and outputs
+        // load the model
+        .model_for_path("resnet.onnx")?
+        // specify input type and shape
+        .with_input_fact(0, InferenceFact::dt_shape(f32::datum_type(), tvec!(1, 3, 224, 224)))?
+        // optimize the model
+        .into_optimized()?
+        // make the model runnable and fix its inputs and outputs
+        .into_runnable()?;
 
     // Imagenet mean and standard deviation
     let mean = Array::from_shape_vec((1, 3, 1, 1), vec![0.485, 0.456, 0.406])?;

--- a/examples/tensorflow-mobilenet-v2/README.md
+++ b/examples/tensorflow-mobilenet-v2/README.md
@@ -61,36 +61,32 @@ $ cat -n imagenet_slim_labels.txt | grep -C 3 654
 Everything happens in [src/main.rs](src/main.rs).
 
 ```rust
-    // load the model
-    let mut model =
-        tract_tensorflow::tensorflow().model_for_path("mobilenet_v2_1.4_224_frozen.pb")?;
+let model = tract_tensorflow::tensorflow()
+    .model_for_path("mobilenet_v2_1.4_224_frozen.pb")? // load the model
+    .with_input_fact(0, InferenceFact::dt_shape(f32::datum_type(), tvec!(1, 224, 224, 3)))? // specify input type and shape
+    .into_optimized()? // optimize the model
+    .into_runnable()?; // make the model runnable and fix its inputs and outputs
 
-    // specify input type and shape
-    model.set_input_fact(0, InferenceFact::dt_shape(f32::datum_type(), tvec!(1, 224, 224, 3)))?;
+// open image, resize it and make a Tensor out of it
+let image = image::open("grace_hopper.jpg").unwrap().to_rgb();
+let resized =
+    image::imageops::resize(&image, 224, 224, ::image::imageops::FilterType::Triangle);
+let image: Tensor = tract_ndarray::Array4::from_shape_fn((1, 224, 224, 3), |(_, y, x, c)| {
+    resized[(x as _, y as _)][c] as f32 / 255.0
+})
+.into();
 
-    // optimize the model and get an execution plan
-    let model = model.into_optimized()?;
-    let plan = SimplePlan::new(&model)?;
+// run the model on the input
+let result = model.run(tvec!(image))?;
 
-    // open image, resize it and make a Tensor out of it
-    let image = image::open("grace_hopper.jpg").unwrap().to_rgb();
-    let resized = image::imageops::resize(&image, 224, 224, ::image::FilterType::Triangle);
-    let image: Tensor = ndarray::Array4::from_shape_fn((1, 224, 224, 3), |(_, y, x, c)| {
-        resized[(x as _, y as _)][c] as f32 / 255.0
-    })
-    .into();
-
-    // run the plan on the input
-    let result = plan.run(tvec!(image))?;
-
-    // find and display the max value with its index
-    let best = result[0]
-        .to_array_view::<f32>()?
-        .iter()
-        .cloned()
-        .zip(1..)
-        .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-    println!("result: {:?}", best);
+// find and display the max value with its index
+let best = result[0]
+    .to_array_view::<f32>()?
+    .iter()
+    .cloned()
+    .zip(1..)
+    .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+println!("result: {:?}", best);
 ```
 
 It uses three crates:
@@ -109,8 +105,9 @@ This line creates a tract-tensorflow context, and uses it to load the protobuf
 model.
 
 ```rust
-    let mut model =
-        tract_tensorflow::tensorflow().model_for_path("mobilenet_v2_1.4_224_frozen.pb")?;
+let model = tract_tensorflow::tensorflow()
+    .model_for_path("mobilenet_v2_1.4_224_frozen.pb")?
+// ..
 ```
 
 ### Specifying input size and optimizing.
@@ -125,10 +122,10 @@ RGB (C=3) pictures. We will only process one image at a time (N=1).
 And it operates on single precision floats (aka `f32`).
 
 ```rust
-    model.set_input_fact(0, InferenceFact::dt_shape(f32::datum_type(), tvec!(1, 224, 224, 3)))?;
-
-    let model = model.into_optimized()?;
-    let plan = SimplePlan::new(&model)?;
+// ..
+    .with_input_fact(0, InferenceFact::dt_shape(f32::datum_type(), tvec!(1, 224, 224, 3)))?
+    .into_optimized()?
+    .into_runnable()?;
 ```
 
 Now the model is ready to run, we have an execution plan, so let's prepare the
@@ -142,11 +139,11 @@ normalizing the `u8` input to the `0..1` range. This array is then converted
 into a Tensor.
 
 ```rust
-    let image = image::open("grace_hopper.jpg").unwrap().to_rgb();
-    let resized = image::imageops::resize(&image, 224, 224, ::image::FilterType::Triangle);
-    let image: Tensor = ndarray::Array4::from_shape_fn((1, 224, 224, 3), |(_, y, x, c)| {
-        resized[(x as _, y as _)][c] as f32 / 255.0
-    }).into();
+let image = image::open("grace_hopper.jpg").unwrap().to_rgb();
+let resized = image::imageops::resize(&image, 224, 224, ::image::FilterType::Triangle);
+let image: Tensor = ndarray::Array4::from_shape_fn((1, 224, 224, 3), |(_, y, x, c)| {
+    resized[(x as _, y as _)][c] as f32 / 255.0
+}).into();
 ```
 
 Note that `tract-core` re-export the excellent `ndarray` crate so that it is
@@ -155,7 +152,7 @@ easy to get the right version for tract conversion to work.
 ### Run the network!
 
 ```rust
-    let result = plan.run(tvec!(image))?;
+let result = model.run(tvec!(image))?;
 ```
 
 ### Interpret the result
@@ -166,12 +163,12 @@ category scores (1000 labels plus the dummy one). We need pick the maximum
 score, with its index, and diplay it...
 
 ```rust
-    let best = result[0]
-        .to_array_view::<f32>()?
-        .iter()
-        .cloned()
-        .enumerate()
-        .zip(1..)
-        .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-    println!("result: {:?}", best);
+let best = result[0]
+    .to_array_view::<f32>()?
+    .iter()
+    .cloned()
+    .enumerate()
+    .zip(1..)
+    .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+println!("result: {:?}", best);
 ```

--- a/examples/tensorflow-mobilenet-v2/src/main.rs
+++ b/examples/tensorflow-mobilenet-v2/src/main.rs
@@ -2,10 +2,14 @@ use tract_tensorflow::prelude::*;
 
 fn main() -> TractResult<()> {
     let model = tract_tensorflow::tensorflow()
-        .model_for_path("mobilenet_v2_1.4_224_frozen.pb")? // load the model
-        .with_input_fact(0, InferenceFact::dt_shape(f32::datum_type(), tvec!(1, 224, 224, 3)))? // specify input type and shape
-        .into_optimized()? // optimize the model
-        .into_runnable()?; // make the model runnable and fix its inputs and outputs
+        // load the model
+        .model_for_path("mobilenet_v2_1.4_224_frozen.pb")?
+        // specify input type and shape
+        .with_input_fact(0, InferenceFact::dt_shape(f32::datum_type(), tvec!(1, 224, 224, 3)))?
+        // optimize the model
+        .into_optimized()?
+        // make the model runnable and fix its inputs and outputs
+        .into_runnable()?;
 
     // open image, resize it and make a Tensor out of it
     let image = image::open("grace_hopper.jpg").unwrap().to_rgb();

--- a/examples/tensorflow-mobilenet-v2/src/main.rs
+++ b/examples/tensorflow-mobilenet-v2/src/main.rs
@@ -1,16 +1,11 @@
 use tract_tensorflow::prelude::*;
 
 fn main() -> TractResult<()> {
-    // load the model
-    let mut model =
-        tract_tensorflow::tensorflow().model_for_path("mobilenet_v2_1.4_224_frozen.pb")?;
-
-    // specify input type and shape
-    model.set_input_fact(0, InferenceFact::dt_shape(f32::datum_type(), tvec!(1, 224, 224, 3)))?;
-
-    // optimize the model and get an execution plan
-    let model = model.into_optimized()?;
-    let plan = SimplePlan::new(&model)?;
+    let model = tract_tensorflow::tensorflow()
+        .model_for_path("mobilenet_v2_1.4_224_frozen.pb")? // load the model
+        .with_input_fact(0, InferenceFact::dt_shape(f32::datum_type(), tvec!(1, 224, 224, 3)))? // specify input type and shape
+        .into_optimized()? // optimize the model
+        .into_runnable()?; // make the model runnable and fix its inputs and outputs
 
     // open image, resize it and make a Tensor out of it
     let image = image::open("grace_hopper.jpg").unwrap().to_rgb();
@@ -21,8 +16,8 @@ fn main() -> TractResult<()> {
     })
     .into();
 
-    // run the plan on the input
-    let result = plan.run(tvec!(image))?;
+    // run the model on the input
+    let result = model.run(tvec!(image))?;
 
     // find and display the max value with its index
     let best = result[0]

--- a/onnx/src/model.rs
+++ b/onnx/src/model.rs
@@ -120,7 +120,7 @@ impl<'a> ParsingContext<'a> {
             let id = model.add_node(name, op, facts)?;
             for (ix, output) in pbnode.output.iter().filter(|s| !s.is_empty()).enumerate() {
                 outlets_by_name.insert(output.to_owned(), OutletId::new(id, ix));
-                model.set_outlet_label(OutletId::new(id, ix), output.to_owned());
+                model.set_outlet_label(OutletId::new(id, ix), output.to_owned())?;
             }
             for closure in closures {
                 trace!("Node {} closes on {}", model.nodes()[id], closure);

--- a/tensorflow/src/model.rs
+++ b/tensorflow/src/model.rs
@@ -192,7 +192,7 @@ impl Tensorflow {
                 let outlet = OutletId::new(prec, input.1);
                 let inlet = InletId::new(node_id, ix);
                 model.add_edge(outlet, inlet)?;
-                model.set_outlet_label(outlet, i.to_string());
+                model.set_outlet_label(outlet, i.to_string())?;
             }
             for i in pbnode.input.iter().filter(|n| n.starts_with("^")) {
                 let input = Self::parse_input(i)?;


### PR DESCRIPTION
- Added `with_xxx` convenience methods to allow building models in a more fluent style.
- Added `into_runnable` model which returns a `type RunnableModel<F, O, M> = SimplePlan<F, O, M>` to more fluently create runnable models.

I noticed an inconsistency in that `set_output_label` did not return a `TractResult<()>` like other `set_xxx` methods so I went ahead and fixed that.

I also converted the examples to use the new syntax. If you don't want to do that just yet I'm fine with undoing it.